### PR TITLE
only set the contact image when it's a URL

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1689,9 +1689,15 @@ Fliplet.Widget.instance('chat', function (data) {
         ? person.data['flChatFirstName'] + ' ' + person.data['flChatLastName']
         : person.data['flChatFullName'];
       otherPeopleSorted[index].title = person.data[titleColumnName] || person.data.flChatDescription;
-      otherPeopleSorted[index].image = person.data[avatarColumnName];
       otherPeopleSorted[index].isPinned = person.data.isPinned;
       otherPeopleSorted[index].isChannel = !!person.isChannel;
+
+      var image = person.data[avatarColumnName];
+
+      // Only set the contact image when it's a URL
+      if (typeof image === 'string' && image.match(/^https?:\/\//)) {
+        otherPeopleSorted[index].image = image;
+      }
     });
 
     renderListOfPeople(otherPeopleSorted, fromSearch);


### PR DESCRIPTION
Avoids this:

![img](https://cl.ly/a6b79e61f779/Image%2525202019-02-26%252520at%2525201.50.33%252520PM.png)