### PR TITLE
Fix selected people thumbnail alignment

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -825,6 +825,7 @@ html.native body,
 }
 
 .show-selected-users {
+  display: flex;
   position: fixed;
   top: 112px;
   left: 0;
@@ -878,7 +879,7 @@ html.native body,
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 2;
+  z-index: 3;
   border-radius: 55px;
   background-size: cover;
   background-position: center center;


### PR DESCRIPTION
Before:
![Screenshot 2019-03-22 at 17 08 37](https://user-images.githubusercontent.com/7046481/54840601-47e57880-4cc5-11e9-9a44-2bd1ae27697b.png)

After:
![Screenshot 2019-03-22 at 17 08 12](https://user-images.githubusercontent.com/7046481/54840618-4caa2c80-4cc5-11e9-862e-68f9f853c4bd.png)
