### PR TITLE
Save widgetInstanceId, appId and pageId in message data

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1122,7 +1122,9 @@ Fliplet.Widget.instance('chat', function (data) {
             imageHeight: files ? files.imageHeight : undefined,
             sentTime: new Date(),
             conversationId: currentConversation.id,
-            widgetInstanceId: data.id
+            widgetInstanceId: data.id,
+            appId: Fliplet.Env.get('appId'),
+            pageId: Fliplet.Env.get('pageId')
           };
 
           messagesQueue.push(messageData);

--- a/js/build.js
+++ b/js/build.js
@@ -1121,7 +1121,8 @@ Fliplet.Widget.instance('chat', function (data) {
             imageWidth: files ? files.imageWidth : undefined,
             imageHeight: files ? files.imageHeight : undefined,
             sentTime: new Date(),
-            conversationId: currentConversation.id
+            conversationId: currentConversation.id,
+            widgetInstanceId: data.id
           };
 
           messagesQueue.push(messageData);


### PR DESCRIPTION
This will be used by the backend to read the chat configuration and understand things like which data source columns are used for the user's first name and last name so notifications look better. 

---
API PR ref https://github.com/Fliplet/fliplet-api/pull/3268