### PR TITLE
Added refresh contacts after clicking start-new conversation button

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -254,6 +254,15 @@ Fliplet.Widget.instance('chat', function (data) {
     isViewingChannels = false;
     switchToContactsList();
 
+    // Reset contacts list if limit is ON
+    if (data.limitContacts) {
+      showStartIndex = 0;
+      howManyEntriesToShow = data.howManyEntriesToShow;
+      showEndIndex = howManyEntriesToShow;
+      totalEntriesToShow = [];
+      renderListOfPeople(otherPeopleSorted);
+    }
+
     $wrapper.addClass('in-contacts');
   }
 


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#3879

## Description
When the user clicks on start-new conversation button contacts refreshed. 

## Screenshots/screencasts
![contacts-fix](https://user-images.githubusercontent.com/52824207/65602760-1a97c100-dfad-11e9-88e1-9f1251a30c38.gif)

## Backward compatibility
This change is fully backward compatible.