### PR TITLE
User is no longer able to select same person after clicking "load more" button

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1276,6 +1276,10 @@ Fliplet.Widget.instance('chat', function (data) {
       })
       .on('click', '.show-more-contacts .btn', function() {
         renderListOfPeople(otherPeopleSorted);
+        contactsSelected.forEach(function(elem) {
+          var contactId = "[data-contact-id='" + elem.id + "']";
+          $(contactId).addClass('contact-selected');
+        });
       })
       .on('change', '[name="group-tabs"]', function () {
         isViewingChannels = !!$('[name="group-tabs"]:checked').val();


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4156

## Description
After clicking on "load more" button, contacts get rerendered and to the ones which are selected class 'contact-selected' added by id.

## Screenshots/screencasts
![select demo](https://user-images.githubusercontent.com/52824207/65754784-7764ba00-e11a-11e9-8121-9f45fb351d10.gif)

## Backward compatibility
This change is fully backward compatible.