### PR TITLE
Showed centered 'show more' dots in the MS IE 11

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -284,6 +284,7 @@ html.native body,
   margin: 8px 5px 8px 15px;
   flex: 1;
   align-self: center;
+  min-height: 50px;
 }
 
 .no-touchevents .chat-card-holder:active,


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5161

## Description
Showed centered 'show more' dots in the MS IE 11

## Screenshots/screencasts
![IE dots fix](https://user-images.githubusercontent.com/53430352/69415746-dc551e80-0d1d-11ea-8833-7ee823529b9d.png)


## Backward compatibility

This change is fully backward compatible.