### PR TITLE
Dots overlay in the MS IE 11 looked like in the other browsers

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -1546,6 +1546,10 @@ html.native body,
   color: #337ab7;
 }
 
+.icon-show-more {
+  min-height: 70px;
+}
+
 @media screen and (min-width: 640px) {
   .offline-note,
   .top-header {


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5161

## Description
Dots overlay in the MS IE 11 looked like in the other browsers

## Screenshots/screencasts
MS IE 11
![IE11](https://user-images.githubusercontent.com/53430352/69623519-b98f7680-104b-11ea-8713-600a7e7ad706.png)

MS Edge
![Edge](https://user-images.githubusercontent.com/53430352/69623528-c0b68480-104b-11ea-9894-495363f2097c.png)

Safari
<img width="378" alt="safari" src="https://user-images.githubusercontent.com/53430352/69623572-cf04a080-104b-11ea-8b0b-043da5eb625b.png">

Firefox
![Firefox](https://user-images.githubusercontent.com/53430352/69623588-d6c44500-104b-11ea-8546-baf809c4ad15.png)

Chrome
![Chrome](https://user-images.githubusercontent.com/53430352/69623601-db88f900-104b-11ea-8df9-c8baa30344ea.png)


## Backward compatibility

This change is fully backward compatible.