### PR TITLE
User will see the full description when no chats is created in the IE 11

### DIFF
--- a/build.html
+++ b/build.html
@@ -13,7 +13,7 @@
     <p>Verify that you are logged in. Try again by<br> pressing the <strong>Refresh</strong> button below.</p>
     <div class="btn refresh-chat" refresh-chat>Refresh</div>
   </div>
-  <div class="empty-area"><p class="empty-area-information">To start messaging contacts tap the <i class="fa fa-pencil-square-o"></i> at the top of your screen.</p></div>
+  <div class="empty-area"><p>To start messaging contacts tap the <i class="fa fa-pencil-square-o"></i> at the top of your screen.</p></div>
   <div class="chat-list">
     <!-- Conversation groups will be here -->
   </div>

--- a/build.html
+++ b/build.html
@@ -13,7 +13,7 @@
     <p>Verify that you are logged in. Try again by<br> pressing the <strong>Refresh</strong> button below.</p>
     <div class="btn refresh-chat" refresh-chat>Refresh</div>
   </div>
-  <div class="empty-area"><p>To start messaging contacts tap the <i class="fa fa-pencil-square-o"></i> at the top of your screen.</p></div>
+  <div class="empty-area"><p class="empty-area-information">To start messaging contacts tap the <i class="fa fa-pencil-square-o"></i> at the top of your screen.</p></div>
   <div class="chat-list">
     <!-- Conversation groups will be here -->
   </div>

--- a/css/chat.css
+++ b/css/chat.css
@@ -1663,3 +1663,7 @@
     padding-bottom: 44px;
   }
 }
+
+.empty-area .empty-area-information {
+  max-width: 100% !important;
+}

--- a/css/chat.css
+++ b/css/chat.css
@@ -124,6 +124,10 @@
   z-index: 1;
 }
 
+.empty-area {
+  flex-flow: row nowrap;
+}
+
 .chat-holder.loading .loading-area,
 .chat-holder.error .error-area,
 .chat-holder.empty .empty-area {
@@ -1662,8 +1666,4 @@
   .fl-bar-padding .chat-input-controls {
     padding-bottom: 44px;
   }
-}
-
-.empty-area .empty-area-information {
-  max-width: 100% !important;
 }


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5336

## Description
User will see the full description when no chats are created in the IE 11

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/70983484-8166db00-20c1-11ea-9db0-696dcbb37c19.png)

## Backward compatibility

This change is fully backward compatible.