### PR TITLE
Allow users to different data sources between the chat and login data source

### DIFF
--- a/build.html
+++ b/build.html
@@ -10,7 +10,7 @@
   <div class="offline-note"><i class="fa fa-spinner fa-pulse"></i> Searching for network...</div>
   <div class="loading-area"><span>Loading</span> <i class="fa fa-spinner fa-pulse"></i></div>
   <div class="error-area">
-    <p>Verify that you are logged in. Try again by<br> pressing the <strong>Refresh</strong> button below.</p>
+    <p>Verify that you are can access this feature. Try again by<br> pressing the <strong>Refresh</strong> button below.</p>
     <div class="btn refresh-chat" refresh-chat>Refresh</div>
   </div>
   <div class="empty-area"><p>To start messaging contacts tap the <i class="fa fa-pencil-square-o"></i> at the top of your screen.</p></div>

--- a/js/build.js
+++ b/js/build.js
@@ -2690,10 +2690,16 @@ Fliplet.Widget.instance('chat', function (data) {
         return email;
       }
 
+      var options = {
+        crossLoginColumnName: crossLoginColumnName
+      };
+
       // Fallback to use session data as the usage of
       // the fl-chat-auth-email app storage is deprecated.
-      return Fliplet.User.getCachedSession().then(function (session) {
-        email = _.get(session, ['entries', 'dataSource', 'data', crossLoginColumnName]);
+      return Fliplet.Hooks.run('flChatGetUserEmail', options).then(function () {
+        return Fliplet.User.getCachedSession();
+      }).then(function (session) {
+        email = _.get(session, ['entries', 'dataSource', 'data', (options.crossLoginColumnName || crossLoginColumnName)]);
 
         if (!email) {
           return Promise.reject('User email not found. Please make sure the user is logged in.');

--- a/js/build.js
+++ b/js/build.js
@@ -2804,7 +2804,7 @@ Fliplet.Widget.instance('chat', function (data) {
           where[crossLoginColumnName] = { $iLike: email };
           return chat.login(where, { offline: true });
         }).catch(function (error) {
-          redirectToLogin();
+          // User not found in data source
           return Promise.reject(error);
         });
       }

--- a/js/build.js
+++ b/js/build.js
@@ -2696,7 +2696,7 @@ Fliplet.Widget.instance('chat', function (data) {
 
       // Fallback to use session data as the usage of
       // the fl-chat-auth-email app storage is deprecated.
-      return Fliplet.Hooks.run('flChatGetUserEmail', options).then(function () {
+      return Fliplet.Hooks.run('flChatBeforeGetUserEmail', options).then(function () {
         return Fliplet.User.getCachedSession();
       }).then(function (session) {
         email = _.get(session, ['entries', 'dataSource', 'data', (options.crossLoginColumnName || crossLoginColumnName)]);
@@ -2711,7 +2711,7 @@ Fliplet.Widget.instance('chat', function (data) {
   }
 
   function redirectToLogin() {
-    return Fliplet.Hooks.run('flChatRedirectToLogin', securityScreenAction).then(function () {
+    return Fliplet.Hooks.run('flChatBeforeRedirectToLogin', securityScreenAction).then(function () {
       if (!_.get(securityScreenAction, 'page')) {
         return Fliplet.App.Storage.remove('fl_enforce_user_data').then(Fliplet.Navigate.toDefault);
       }

--- a/js/build.js
+++ b/js/build.js
@@ -2707,7 +2707,7 @@ Fliplet.Widget.instance('chat', function (data) {
   function redirectToLogin() {
     return Fliplet.Hooks.run('flChatRedirectToLogin', securityScreenAction).then(function () {
       if (!_.get(securityScreenAction, 'page')) {
-        return Fliplet.Navigate.toDefault();
+        return Fliplet.App.Storage.remove('fl_enforce_user_data').then(Fliplet.Navigate.toDefault);
       }
 
       return Fliplet.Navigate.to(securityScreenAction);


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/5169

When verifying user login, developers can use the `flChatGetUserEmail` hook to change the `crossLoginColumnName` field name:

```js
Fliplet.Hooks.on('flChatBeforeGetUserEmail', function (options) {
  options.crossLoginColumnName = 'Authorized emails';
});
```