### PR TITLE
[Fix] Allow chat contacts to provide an array for the thumbnail

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1853,6 +1853,10 @@ Fliplet.Widget.instance('chat', function (data) {
       user.data.flChatLastName = user.data[lastNameColumnName] || '';
       user.data.flChatFullName = user.data[fullNameColumnName] || '';
 
+      if (avatarColumnName && Array.isArray(user.data[avatarColumnName])) {
+        user.data[avatarColumnName] = _.first(user.data[avatarColumnName]);
+      }
+
       // Filter profiles without a name
       if (!user.data.flChatFirstName && !user.data.flChatLastName && !user.data.flChatFullName) {
         return;


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/6843

---

If the list of contacts is made of profiles created through a form, the image field is an array of uploaded files and the chat does not seem to be able to display the thumbnail using the first image in the array.