### PR TITLE
ID-358 [Fix] Prevent chat UI being blocked by overlay in tablet view

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -531,7 +531,7 @@ html.no-supports-container.native body,
   bottom: 0;
   left: 0;
   background: #ffffff;
-  z-index: 9;
+  z-index: 11;
   -webkit-transform: translate3d(100%, 0, 0);
   transform: translate3d(100%, 0, 0);
   transition: all 0.2s ease-out;


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-358

z-index was lowered from 1012 to 9 in this PR. However, the tablet overlay screening element is at 11, which results in the chat UI being blocked.