### PR TITLE
ID-384 Ensure an invalid data source ID is not given to the JS API

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -139,6 +139,7 @@ Fliplet.Widget.instance('chat', function (data) {
 
   if (data.dataSourceId === 'none') {
     delete data.dataSourceId;
+    Fliplet.UI.Toast('Cannot connect to contact list. Please check it\'s configured correctly.');
   }
 
   var securityScreenAction = data.securityLinkAction;

--- a/js/build.js
+++ b/js/build.js
@@ -137,6 +137,10 @@ Fliplet.Widget.instance('chat', function (data) {
     multipleNameColumns = true;
   }
 
+  if (data.dataSourceId === 'none') {
+    delete data.dataSourceId;
+  }
+
   var securityScreenAction = data.securityLinkAction;
   var chatConnection = Fliplet.Chat.connect({
     encryptMessages: true,


### PR DESCRIPTION
This patch makes sure a proper error is presented to the user when the contacts data source is not configured, instead of behaving as if an ID was selected.