### PR TITLE
OD-234 [Feature] Showing chat in fullscreen on mobile devices

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -181,8 +181,7 @@ html.no-supports-container.native body,
   transition: opacity 0.1s ease-out, transform 0.2s ease-out, padding-top 0.2s ease-out;
 }
 
-.fl-with-bottom-menu .chat-holder .chat-list
- {
+.fl-with-bottom-menu .chat-holder .chat-list {
   margin-bottom: 80px;
   margin-bottom: calc(80px + env(safe-area-inset-bottom));
 }

--- a/css/chat.css
+++ b/css/chat.css
@@ -181,8 +181,7 @@ html.no-supports-container.native body,
   transition: opacity 0.1s ease-out, transform 0.2s ease-out, padding-top 0.2s ease-out;
 }
 
-.fl-with-bottom-menu .chat-holder .chat-list,
-.fl-with-bottom-menu .chat-area
+.fl-with-bottom-menu .chat-holder .chat-list
  {
   margin-bottom: 80px;
   margin-bottom: calc(80px + env(safe-area-inset-bottom));
@@ -531,7 +530,7 @@ html.no-supports-container.native body,
   bottom: 0;
   left: 0;
   background: #ffffff;
-  z-index: 11;
+  z-index: 1010;
   -webkit-transform: translate3d(100%, 0, 0);
   transform: translate3d(100%, 0, 0);
   transition: all 0.2s ease-out;

--- a/js/build.js
+++ b/js/build.js
@@ -62,6 +62,9 @@ Fliplet.Widget.instance('chat', function (data) {
   var clipboardjs;
   var autosizeInit = false;
   var isEditing = false;
+  var bodyPaddingTop = $('body').css('padding-top');
+  var hasTopMenu = $('body').hasClass('fl-with-top-menu');
+  var isMobile = $('html').hasClass('mobile');
   /** PHOTOSWIPE **/
   var photoswipeHtml = '<!-- Root element of PhotoSwipe. Must have class pswp. --> <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true"> <!-- Background of PhotoSwipe. It s a separate element as animating opacity is faster than rgba(). --> <div class="pswp__bg"></div> <!-- Slides wrapper with overflow:hidden. --> <div class="pswp__scroll-wrap"> <!-- Container that holds slides. PhotoSwipe keeps only 3 of them in the DOM to save memory. Don t modify these 3 pswp__item elements, data is added later on. --> <div class="pswp__container"> <div class="pswp__item"></div> <div class="pswp__item"></div> <div class="pswp__item"></div> </div> <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. --> <div class="pswp__ui pswp__ui--hidden"> <div class="pswp__top-bar"> <!-- Controls are self-explanatory. Order can be changed. --> <div class="pswp__counter"></div> <button class="pswp__button pswp__button--close" title="Close (Esc)"></button> <!-- <button class="pswp__button pswp__button--share" title="Share"> --> </button> <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button> <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button> <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR --> <!-- element will get class pswp__preloader--active when preloader is running --> <div class="pswp__preloader"> <div class="pswp__preloader__icn"> <div class="pswp__preloader__cut"> <div class="pswp__preloader__donut"></div> </div> </div> </div> </div> <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap"> <div class="pswp__share-tooltip"></div> </div> <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"> </button> <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"> </button> <div class="pswp__caption"> <div class="pswp__caption__center"></div> </div> </div> </div> </div>';
   // Check if there's already
@@ -259,6 +262,12 @@ Fliplet.Widget.instance('chat', function (data) {
     $('.chat-card-holder[data-conversation-id="'+ conversationId +'"]').addClass('open');
   }
 
+  function showChatInFullScreen() {
+    if (hasTopMenu && isMobile) {
+      $wrapper.css('top', '-' + bodyPaddingTop);
+    }
+  }
+
   function openContacts() {
     // Reset to contacts list
     isViewingChannels = false;
@@ -356,6 +365,7 @@ Fliplet.Widget.instance('chat', function (data) {
 
   function closeConversation(clickedChat) {
     $wrapper.removeClass('chat-open');
+    $wrapper.css('top', '');
     $('.long-pressed').removeClass('long-pressed');
     $('.chat-area').removeClass('message-focused');
     $('.chat-card-holder').removeClass('open');
@@ -792,6 +802,8 @@ Fliplet.Widget.instance('chat', function (data) {
   }
 
   function createNewChatGroupSettings() {
+    showChatInFullScreen();
+
     if (isViewingChannels) {
       return joinPublicChannel();
     }
@@ -927,6 +939,8 @@ Fliplet.Widget.instance('chat', function (data) {
       })
       .on('click', '.chat-card-holder[data-conversation-id]', function() {
         if (allowClick) {
+          showChatInFullScreen();
+
           var id = $(this).data('conversation-id');
           var conversation = _.find(conversations, { id: id });
 

--- a/js/build.js
+++ b/js/build.js
@@ -262,10 +262,14 @@ Fliplet.Widget.instance('chat', function (data) {
     $('.chat-card-holder[data-conversation-id="'+ conversationId +'"]').addClass('open');
   }
 
-  function showChatInFullScreen() {
+  function enterChatFullScreen() {
     if (hasTopMenu && isMobile) {
       $wrapper.css('top', '-' + bodyPaddingTop);
     }
+  }
+
+  function exitChatFullScreen() {
+    $wrapper.css('top', '');
   }
 
   function openContacts() {
@@ -365,7 +369,7 @@ Fliplet.Widget.instance('chat', function (data) {
 
   function closeConversation(clickedChat) {
     $wrapper.removeClass('chat-open');
-    $wrapper.css('top', '');
+    exitChatFullScreen();
     $('.long-pressed').removeClass('long-pressed');
     $('.chat-area').removeClass('message-focused');
     $('.chat-card-holder').removeClass('open');
@@ -802,7 +806,7 @@ Fliplet.Widget.instance('chat', function (data) {
   }
 
   function createNewChatGroupSettings() {
-    showChatInFullScreen();
+    enterChatFullScreen();
 
     if (isViewingChannels) {
       return joinPublicChannel();
@@ -939,7 +943,7 @@ Fliplet.Widget.instance('chat', function (data) {
       })
       .on('click', '.chat-card-holder[data-conversation-id]', function() {
         if (allowClick) {
-          showChatInFullScreen();
+          enterChatFullScreen();
 
           var id = $(this).data('conversation-id');
           var conversation = _.find(conversations, { id: id });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-234

## Description
Showing chat in full screen on mobile devices

## Screenshots/screencasts
https://share.getcloudapp.com/P8uyJR8N

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
1. Current solution doesn't design for dynamical change of the resolution, as you may see at the and of the video. Should we change that?
2. As I've found menu size is equal to the body padding-top, so I take its value to set `top` in `.chat-holder` in this way we will always set the correct top value for the chat without the risk that it will be moved out of the viewport.
I've tested it on Studio preview, Android 9, and Android 10 in the Fliplet viewer.
[Android 9 screencast](https://share.getcloudapp.com/Blu1nNx0) (real device Xiaomi MI A1)
[Android 10 screencast](https://share.getcloudapp.com/6quPjBPP) (virtual machine power by Genymotion)