### PR TITLE
OD-362 [Fix] Avoid message render adjusting after conversation is muted

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1042,6 +1042,7 @@ Fliplet.Widget.instance('chat', function(data) {
         event.stopPropagation();
         toggleNotifications(currentConversation.id).then(function() {
           $messages.html('');
+          $messagesHolder.html(chatMessageGapTemplate());
           viewConversation(currentConversation);
         });
       })

--- a/js/build.js
+++ b/js/build.js
@@ -1041,8 +1041,7 @@ Fliplet.Widget.instance('chat', function(data) {
         event.preventDefault();
         event.stopPropagation();
         toggleNotifications(currentConversation.id).then(function() {
-          $messages.html('');
-          $messagesHolder.html(chatMessageGapTemplate());
+          $messages.html(chatMessageGapTemplate());
           viewConversation(currentConversation);
         });
       })


### PR DESCRIPTION
@romanyosyfiv

OD-362 https://weboo.atlassian.net/browse/OD-362

## Description
**Problem**: No chatMessageGapTemplate was added after clearing the chat
**Solution**: After clearing the chat, the chatMessageGapTemplate is added

Backward compatibility
This change is fully backward compatible.

Reviewers
@upplabs-alex-levchenko