### PR TITLE
XOR-549 [Fix] Ensure a user who has left the chat group is not displayed as group participant

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -2298,13 +2298,12 @@ Fliplet().then(function() {
         // Add a readable name to the conversation, based on the other people in the group
         conversations.forEach(function(conversation) {
           var participants = _.get(conversation, 'definition.participants', []);
-          var allParticipants = _.compact(_.concat(participants, _.get(conversation, 'definition.removedParticipants', [])));
 
           // Client specific
           addUsersToAdminGroups(conversation);
 
           var conversationName = _.compact(_.filter(otherPeople, function(c) {
-            return allParticipants.indexOf(c.data.flUserId) !== -1;
+            return participants.indexOf(c.data.flUserId) !== -1;
           }).map(function(c) {
             return multipleNameColumns
               ? c.data['flChatFirstName'] + ' ' + c.data['flChatLastName']


### PR DESCRIPTION
### Product areas affected

Widgets -> Chat Widget  -> Select Contact from List to chat -> Create group -> Left group

### What does this PR do?

Implemented fix so that a user who has left the chat group is not displayed as group participant on Group tile

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-549)

### Result

https://user-images.githubusercontent.com/108272606/227904008-bc0b79c8-615d-411a-9992-6c7c07065899.mp4

### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none