### PR TITLE
XOR-547 [Fix] Fixes UI error for when the last sent message is too long to display

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -481,7 +481,8 @@ html.no-supports-container.native body,
 }
 
 .chat-card-holder .chat-participants-preview,
-.chat-card-holder .chat-participants-preview + .chat-user-preview {
+.chat-card-holder .chat-participants-preview + .chat-user-preview,
+.chat-card-holder .chat-user-preview {
   -webkit-line-clamp: 1;
   word-break: break-all;
 }

--- a/css/chat.css
+++ b/css/chat.css
@@ -483,6 +483,7 @@ html.no-supports-container.native body,
 .chat-card-holder .chat-participants-preview,
 .chat-card-holder .chat-participants-preview + .chat-user-preview {
   -webkit-line-clamp: 1;
+  word-break: break-all;
 }
 
 .contact-card.contact-selected .contact-user-preview {


### PR DESCRIPTION
### Product areas affected

Studio -> Chat -> Create group

### What does this PR do?

Implemented fix so that the last sent message displayed on the group list doesn't go beyond the tile and blocks chat group actions 

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-547)

### Result

https://user-images.githubusercontent.com/108272606/230355945-04fb2853-c2e2-47e7-8e4a-2afdeee2829b.mp4

### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none