### PR TITLE
ID-2804 [FIX] Ensure attached images are not saved with the wrong orientation

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1542,7 +1542,8 @@ Fliplet().then(function() {
             }, {
               canvas: true,
               maxWidth: maxWidth,
-              maxHeight: maxHeight
+              maxHeight: maxHeight,
+              orientation: 0
             }
           );
         }

--- a/js/build.js
+++ b/js/build.js
@@ -1542,9 +1542,7 @@ Fliplet().then(function() {
             }, {
               canvas: true,
               maxWidth: maxWidth,
-              maxHeight: maxHeight,
-              // Use EXIF data to adjust rotation
-              orientation: (data.exif) ? data.exif.get('Orientation') : true
+              maxHeight: maxHeight
             }
           );
         }


### PR DESCRIPTION
**Product areas affected**

Studio -> Chat -> Add image

**What does this PR do?**

Implemented code, so while adding image in chat conversation should not rotate

**JIRA ticket**

[ID-2804](https://weboo.atlassian.net/browse/ID-2804)

**Result**

https://github.com/Fliplet/fliplet-widget-chat/assets/108272606/8088196c-f6a5-4595-9fb6-5b9f8ee2fc7d

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None

[ID-2804]: https://weboo.atlassian.net/browse/ID-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ