### PR TITLE
ID-3415 [FIX] Chat Group is converted to Chat conversation

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -2351,9 +2351,11 @@ Fliplet().then(function() {
             return participants.indexOf(p.data.flUserId) !== -1;
           });
 
+          var isFriendAvatar = friend ? friend.data[avatarColumnName] : '';
+
           conversation.isChannel = conversation.definition.group && conversation.definition.group.public;
           conversation.name = participants.length >= 2 || conversation.isChannel ? conversation.name || 'Group' : conversationName;
-          conversation.avatar = participants.length >= 2 ? '' : friend ? friend.data[avatarColumnName] : '';
+          conversation.avatar = participants.length >= 2 ? '' : isFriendAvatar;
           conversation.isGroup = !conversation.isChannel && participants.length >= 2;
           conversation.usersInConversation = conversationName;
           conversation.nParticipants = participants.length;

--- a/js/build.js
+++ b/js/build.js
@@ -2352,9 +2352,9 @@ Fliplet().then(function() {
           });
 
           conversation.isChannel = conversation.definition.group && conversation.definition.group.public;
-          conversation.name = participants.length > 2 || conversation.isChannel ? conversation.name || 'Group' : conversationName;
-          conversation.avatar = participants.length > 2 ? '' : friend ? friend.data[avatarColumnName] : '';
-          conversation.isGroup = !conversation.isChannel && participants.length > 2;
+          conversation.name = participants.length >= 2 || conversation.isChannel ? conversation.name || 'Group' : conversationName;
+          conversation.avatar = participants.length >= 2 ? '' : friend ? friend.data[avatarColumnName] : '';
+          conversation.isGroup = !conversation.isChannel && participants.length >= 2;
           conversation.usersInConversation = conversationName;
           conversation.nParticipants = participants.length;
           conversation.absoluteTime = TD(conversation.updatedAt, { format: 'fromNow' });


### PR DESCRIPTION
**Observed:** Chat Group is converted to Chat conversation  and loses its name when there are only two participants left .If User A already have an existing chat conversation with User C, two chat conversations will be displayed for both users

**Expected:** Chat Group should remain group and keep its name when there are only two participants left