### PR TITLE
PS-2123 [FIX] Render restored conversation history when reopening a deleted 1:1 chat

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -2199,7 +2199,7 @@ Fliplet().then(function() {
 
           scrollToMessageTs = 100;
           $messagesHolder.html(chatMessageGapTemplate());
-          viewConversation(newConversation, conversation.isNew);
+          viewConversation(newConversation);
         });
       }).catch(function(error) {
         $('.contacts-done-holder').removeClass('creating');
@@ -2471,7 +2471,7 @@ Fliplet().then(function() {
       }
     }
 
-    function viewConversation(conversation, isNew = true) {
+    function viewConversation(conversation) {
       $wrapper.addClass('chat-open');
       openConversation(conversation.id);
 
@@ -2515,7 +2515,8 @@ Fliplet().then(function() {
           message.fromChannel = true;
         }
 
-        if ((!message.isDeleted || message.deletedAt === null) && isNew) {
+        // PS-2123: render history unconditionally; restored conversations arrive with existing data
+        if (!message.isDeleted || message.deletedAt === null) {
           renderMessage(message);
         }
       });
@@ -2581,6 +2582,11 @@ Fliplet().then(function() {
     }
 
     function renderMessage(message, prepend) {
+      // PS-2123: skip messages already in the DOM, e.g. when the poll re-emits rendered history
+      if ($('[data-message-id="' + message.id + '"]').length) {
+        return;
+      }
+
       if (scrollToMessageTimeout) {
         clearTimeout(scrollToMessageTimeout);
         scrollToMessageTimeout = undefined;


### PR DESCRIPTION
### Product areas affected
Chat widget (`com.fliplet.chat`) — conversation view on all platforms (web + native).

### What does this PR do?
Fixes the "reopened conversation is empty" bug: deleting a 1:1 conversation and re-contacting the same person (e.g. via the `contactEmail` query parameter) restores the existing conversation server-side (`existing: true` → `isNew = false`), but `viewConversation` only rendered message history when `isNew` was true — so the restored conversation opened blank and only filled in if a background poll succeeded.

Changes:
1. **Render history unconditionally** in `viewConversation` (removed the `&& isNew` gate and the now-unused `isNew` parameter). This is safe against double initial renders: all seven call sites clear the message pane (`$messagesHolder.html(...)`) before calling `viewConversation` — verified each one.
2. **Added a dedupe guard at the top of `renderMessage`** (skip if `[data-message-id]` already in the DOM). This is required, not defensive: `createConversation` calls `chat.poll({ reset: true })` right before `viewConversation`, and the reset poll re-emits the same history ~2s later via `onNewMessage → renderMessage` — without the guard the fix would trade "empty conversation" for duplicated messages. The other two `renderMessage` callers are unaffected: the load-older/prepend path already dedupes via `messagesIds` before rendering, and queued own-messages go through `renderQueueMessage` with guid-based ids.

Server-side restore behaviour (delete = `participants.remove()`, re-contact restores the shared record) is intentional and unchanged — see QA verdict on the ticket.

### JIRA ticket
[PS-2123](https://weboo.atlassian.net/browse/PS-2123)

### Result
Before: delete 1:1 chat → reopen via `?contactEmail=` → conversation opens empty (history only appears if/when background sync succeeds).
After: history renders immediately on open; no duplicate messages when the reset poll re-delivers them.

### Checklist
 - [ ] Added automated test coverage as appropriate for this change.

### Deployment instructions
None — widget-only change, standard widget release. No API or data changes.

### Author concerns
- No automated tests exist in this repo; verification is manual. Test plan: (1) delete a 1:1 chat → reopen via `contactEmail` → history renders immediately; (2) open a conversation from the list → history renders once, no duplicates; (3) `contactEmail` to a never-contacted user → empty new conversation, send/receive works; (4) offline-queued messages still render and reconcile.
- This area has a fix/revert history (ID-3415, PRs #137–#142), so both the list-open and contactEmail-open directions should be QA'd before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-2123]: https://weboo.atlassian.net/browse/PS-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ