### PR TITLE
PS-2123 [FIX] Render restored conversation history when reopening a deleted 1:1 chat (production)

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -2199,7 +2199,7 @@ Fliplet().then(function() {
 
           scrollToMessageTs = 100;
           $messagesHolder.html(chatMessageGapTemplate());
-          viewConversation(newConversation, conversation.isNew);
+          viewConversation(newConversation);
         });
       }).catch(function(error) {
         $('.contacts-done-holder').removeClass('creating');
@@ -2471,7 +2471,7 @@ Fliplet().then(function() {
       }
     }
 
-    function viewConversation(conversation, isNew = true) {
+    function viewConversation(conversation) {
       $wrapper.addClass('chat-open');
       openConversation(conversation.id);
 
@@ -2515,7 +2515,8 @@ Fliplet().then(function() {
           message.fromChannel = true;
         }
 
-        if ((!message.isDeleted || message.deletedAt === null) && isNew) {
+        // PS-2123: render history unconditionally; restored conversations arrive with existing data
+        if (!message.isDeleted || message.deletedAt === null) {
           renderMessage(message);
         }
       });
@@ -2581,6 +2582,11 @@ Fliplet().then(function() {
     }
 
     function renderMessage(message, prepend) {
+      // PS-2123: skip messages already in the DOM, e.g. when the poll re-emits rendered history
+      if ($('[data-message-id="' + message.id + '"]').length) {
+        return;
+      }
+
       if (scrollToMessageTimeout) {
         clearTimeout(scrollToMessageTimeout);
         scrollToMessageTimeout = undefined;


### PR DESCRIPTION
### Product areas affected
Chat widget (`com.fliplet.chat`) — conversation view on all platforms (web + native).

### What does this PR do?
Production-track copy of #150 (cherry-pick of `63976ce`, applied cleanly on the `production` base). `master` and `production` have diverged (master removed lodash in #147; production kept it and shipped DEV-764 #148), so this fix is landed separately via `projects/PS-2123`, which was branched from `production`.

Fixes the "reopened conversation is empty" bug: deleting a 1:1 conversation and re-contacting the same person (e.g. via the `contactEmail` query parameter) restores the existing conversation server-side (`existing: true` → `isNew = false`), but `viewConversation` only rendered message history when `isNew` was true — so the restored conversation opened blank and only filled in if a background poll succeeded.

Changes:
1. **Render history unconditionally** in `viewConversation` (removed the `&& isNew` gate and the now-unused `isNew` parameter). Safe against double initial renders: all `viewConversation` call sites clear the message pane first.
2. **Dedupe guard at the top of `renderMessage`** (skip if `[data-message-id]` already in the DOM) — required because `createConversation` calls `chat.poll({ reset: true })`, which re-emits the same history via `onNewMessage → renderMessage` moments later.

See #150 for the full mechanism analysis.

### JIRA ticket
[PS-2123](https://weboo.atlassian.net/browse/PS-2123)

### Result
Before: delete 1:1 chat → reopen via `?contactEmail=` → conversation opens empty.
After: history renders immediately on open; no duplicate messages when the reset poll re-delivers them.

### Checklist
 - [ ] Added automated test coverage as appropriate for this change.

### Deployment instructions
Merging this PR puts the fix on `projects/PS-2123` (branched from `production`). Releasing to production is then `projects/PS-2123` → `production`. Note the master/production divergence: #150 covers the master track; do not close one in favour of the other.

### Author concerns
- `master` and `production` are out of sync in this repo — this dual-track landing is a workaround. The branches should be reconciled after the event to avoid future double-landing (cf. PS-1988, where fixes stranded on projects branches never reached master).
- No automated tests in this repo; manual test plan as in #150: delete → re-contact renders history; list-open renders once with no duplicates; brand-new contact still gets an empty working conversation; queued offline messages still reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-2123]: https://weboo.atlassian.net/browse/PS-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ