### PR TITLE
Release: release/PS-2123 → production

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -2199,7 +2199,7 @@ Fliplet().then(function() {
 
           scrollToMessageTs = 100;
           $messagesHolder.html(chatMessageGapTemplate());
-          viewConversation(newConversation, conversation.isNew);
+          viewConversation(newConversation);
         });
       }).catch(function(error) {
         $('.contacts-done-holder').removeClass('creating');
@@ -2471,7 +2471,7 @@ Fliplet().then(function() {
       }
     }
 
-    function viewConversation(conversation, isNew = true) {
+    function viewConversation(conversation) {
       $wrapper.addClass('chat-open');
       openConversation(conversation.id);
 
@@ -2515,7 +2515,8 @@ Fliplet().then(function() {
           message.fromChannel = true;
         }
 
-        if ((!message.isDeleted || message.deletedAt === null) && isNew) {
+        // PS-2123: render history unconditionally; restored conversations arrive with existing data
+        if (!message.isDeleted || message.deletedAt === null) {
           renderMessage(message);
         }
       });
@@ -2581,6 +2582,11 @@ Fliplet().then(function() {
     }
 
     function renderMessage(message, prepend) {
+      // PS-2123: skip messages already in the DOM, e.g. when the poll re-emits rendered history
+      if ($('[data-message-id="' + message.id + '"]').length) {
+        return;
+      }
+
       if (scrollToMessageTimeout) {
         clearTimeout(scrollToMessageTimeout);
         scrollToMessageTimeout = undefined;


### PR DESCRIPTION
## Release: `release/PS-2123` → `production`

| Title | Ticket | PR |
|-------|--------|-----|
| Render restored conversation history when reopening a deleted 1:1 chat | [PS-2123](https://weboo.atlassian.net/browse/PS-2123) | #151 |

### Deployment instructions
- Widget-only change (`js/build.js`); no API or data changes. Standard widget release to production.
- Client has an event tomorrow (PHARAOHS BALL, app 375775, US region) — release ahead of it if possible.
- Post-release verification: delete a 1:1 chat → reopen via `?contactEmail=` → message history renders immediately, no duplicates; brand-new contact still gets a working empty conversation.
- Note: `master` and `production` are out of sync in this repo. The master-track copy of this fix is #150 (still open) — this release does NOT cover master; both must land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-2123]: https://weboo.atlassian.net/browse/PS-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ